### PR TITLE
Fix humana data pull to fetch data in batches of 2000.

### DIFF
--- a/transparency_in_coverage_filesizes/humana.py
+++ b/transparency_in_coverage_filesizes/humana.py
@@ -7,18 +7,29 @@ cur.execute("CREATE TABLE IF NOT EXISTS in_network_files(url PRIMARY KEY UNIQUE,
 
 params = {
     "fileType": "innetwork",
-    "iDisplayLength": "500000",
+    "iDisplayLength": "2000",
+    "iDisplayStart": 0
 }
 
 print("Fetching URLs and their sizes...")
-resp = requests.get("https://developers.humana.com/Resource/GetData", params = params)
 
-for file in resp.json()["aaData"]:
-    url = "https://developers.humana.com/Resource/DownloadPCTFile?fileType=innetwork&" + file["name"]
-    size = int(file["size"])
-    cur.execute(f"""INSERT OR IGNORE INTO in_network_files VALUES ("{url}", {size})""")
+finished = False
+while not finished:
+    resp = requests.get("https://developers.humana.com/Resource/GetData", params = params) \
+                   .json()
+    if len(resp['aaData']) > 0:
+        for file in resp["aaData"]:
+            url = "https://developers.humana.com/Resource/DownloadPCTFile?fileType=innetwork&" + file["name"]
+            size = int(file["size"])
+            cur.execute(f"""INSERT OR IGNORE INTO in_network_files VALUES ("{url}", {size})""")
+    else:
+        finished = True
 
-con.commit()
+    con.commit()
+    
+    # Update the counter to get the next batch
+    params['iDisplayStart'] += len(resp['aaData'])
+    print(f"\r{params['iDisplayStart']: 6d}/{resp['iTotalRecords']} ({100*params['iDisplayStart']/resp['iTotalRecords']:3.1f}%)", end='')
 
 total = cur.execute("SELECT SUM(size) FROM in_network_files").fetchone()[0]
-print(f"Total filesize in GB: {total//1_000_000_000}")
+print(f"\nTotal filesize in GB: {total//1_000_000_000}")


### PR DESCRIPTION
I noticed that the Humana script as written only pulls data on the first 2000 files reporting a final size of about 160 GB.

I've updated it to instead pull the data in batches of 2000 and included a progress printout with completion percentage. The updated final size of the generated 'humana.db' file is 130 MB and the estimated total size of the files on the Humana server is about 47.5 TB